### PR TITLE
native HTTP calls to avoid future cors issues

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -91,7 +91,6 @@
     <engine name="android" spec="^6.2.3" />
     <engine name="browser" spec="^4.1.0" />
     <engine name="ios" spec="^4.5.4" />
-    <plugin name="cordova-plugin-advanced-http" spec="^1.9.1" />
     <plugin name="cordova-plugin-console" spec="^1.0.7" />
     <plugin name="cordova-plugin-device" spec="^1.1.6" />
     <plugin name="cordova-plugin-inappbrowser" spec="^1.7.1" />
@@ -105,4 +104,5 @@
     <plugin name="phonegap-plugin-barcodescanner" spec="^6.0.8">
         <variable name="CAMERA_USAGE_DESCRIPTION" value="Scan QR-Codes" />
     </plugin>
+    <plugin name="cordova-plugin-advanced-http" spec="~1.11.1" />
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -86,7 +86,7 @@
     <feature name="CDVWKWebViewEngine">
         <param name="ios-package" value="CDVWKWebViewEngine" />
     </feature>
-    <preference name="CordovaWebViewEngine" value="CDVUIWebViewEngine" />
+    <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
     <preference name="SplashShowOnlyFirstTime" value="false" />
     <engine name="android" spec="^6.2.3" />
     <engine name="browser" spec="^4.1.0" />
@@ -94,7 +94,6 @@
     <plugin name="cordova-plugin-console" spec="^1.0.7" />
     <plugin name="cordova-plugin-device" spec="^1.1.6" />
     <plugin name="cordova-plugin-inappbrowser" spec="^1.7.1" />
-    <plugin name="cordova-plugin-ionic-webview" spec="^1.1.16" />
     <plugin name="cordova-plugin-screen-orientation" spec="^1.4.3" />
     <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />
     <plugin name="cordova-plugin-statusbar" spec="^2.2.3" />
@@ -104,9 +103,7 @@
     <plugin name="phonegap-plugin-barcodescanner" spec="^6.0.8">
         <variable name="CAMERA_USAGE_DESCRIPTION" value="Scan QR-Codes" />
     </plugin>
-<<<<<<< HEAD
     <plugin name="cordova-plugin-advanced-http" spec="~1.11.1" />
-=======
     <plugin name="cordova-plugin-globalization" spec="^1.11.0" />
->>>>>>> 74b9487e7eb8e0ea24d1d5d10099fd9504445133
+    <plugin name="cordova-plugin-ionic-webview" spec="^1.1.16" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8283 @@
+{
+    "name": "MyLibreNMS",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@angular-devkit/build-optimizer": {
+            "version": "0.0.35",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.35.tgz",
+            "integrity": "sha512-7JxZZAYFSCc0tP6+NrRn3b2Cd1b9d+a3+OfwVNyNsNd2unelqUMko2hm0KLbC8BXcXt/OILg1E/ZgLAXSS47nw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.1.0",
+                "source-map": "0.5.7",
+                "typescript": "2.6.2",
+                "webpack-sources": "1.1.0"
+            },
+            "dependencies": {
+                "typescript": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+                    "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+                    "dev": true
+                }
+            }
+        },
+        "@angular/common": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.0.0.tgz",
+            "integrity": "sha1-+W1mpRe5ldG6mygwnxXC41lnWCU=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/compiler": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.0.0.tgz",
+            "integrity": "sha1-uf+/GMijnYt9rOxHMZOpDiTMK8k=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/compiler-cli": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.0.0.tgz",
+            "integrity": "sha1-Dsu5N9hKT43ZTwwqR7B9LkaUyFM=",
+            "requires": {
+                "chokidar": "1.7.0",
+                "minimist": "1.2.0",
+                "reflect-metadata": "0.1.12",
+                "tsickle": "0.24.1"
+            }
+        },
+        "@angular/core": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.0.0.tgz",
+            "integrity": "sha1-T5dqIl993fNJkvLK2CTJVDpG9Mg=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/forms": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.0.0.tgz",
+            "integrity": "sha1-x/3fo1OWdZrphSkgowzdqMQe0d4=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/http": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.0.0.tgz",
+            "integrity": "sha1-Byiivgz7sHhyfF64fUyF1T/smlE=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/platform-browser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.0.0.tgz",
+            "integrity": "sha1-xwOPfN6AcFtiAUiXIx4YLuyXb+0=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@angular/platform-browser-dynamic": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.0.tgz",
+            "integrity": "sha1-iH4QbIsQOwQVz2FWpCXabYP0yJ0=",
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "@ionic-native/barcode-scanner": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/@ionic-native/barcode-scanner/-/barcode-scanner-3.14.0.tgz",
+            "integrity": "sha1-2JB1xgaqTWllHlllZ05JEeWFN10="
+        },
+        "@ionic-native/core": {
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-3.10.2.tgz",
+            "integrity": "sha1-RvzgHPmGNyK8RcoI2FYDjtpNdnY="
+        },
+        "@ionic-native/http": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@ionic-native/http/-/http-4.6.0.tgz",
+            "integrity": "sha512-Gi8hMqh04OMfPDaL7102L5MRtX6FXxsQujK5Ygk3rz/2DGutHB6Zb2qRg7OqWGFAW96qy+UBmpPFAjIV+0mUzQ=="
+        },
+        "@ionic-native/screen-orientation": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/@ionic-native/screen-orientation/-/screen-orientation-3.14.0.tgz",
+            "integrity": "sha1-FV9e9MbL+qPD2G6DDkFggoxDz24="
+        },
+        "@ionic-native/splash-screen": {
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-3.10.2.tgz",
+            "integrity": "sha1-9dDKcYivo1LmVLSxRp4cNQMM7Vo="
+        },
+        "@ionic-native/status-bar": {
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@ionic-native/status-bar/-/status-bar-3.10.2.tgz",
+            "integrity": "sha1-W2KGxLudj1dblNAA7o15b9Tyzek="
+        },
+        "@ionic/app-scripts": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@ionic/app-scripts/-/app-scripts-3.1.7.tgz",
+            "integrity": "sha512-wCQsrquCj3HTnmH60Mba20iidKAJMeo112995Wa9gf190VW7AaoHIsUr666Z36q9quqgqRZVuQG3cgF0nLMxHw==",
+            "dev": true,
+            "requires": {
+                "@angular-devkit/build-optimizer": "0.0.35",
+                "autoprefixer": "7.2.6",
+                "chalk": "2.3.2",
+                "chokidar": "1.7.0",
+                "clean-css": "4.1.11",
+                "cross-spawn": "5.1.0",
+                "express": "4.16.3",
+                "fs-extra": "4.0.3",
+                "glob": "7.1.2",
+                "json-loader": "0.5.7",
+                "node-sass": "4.5.3",
+                "os-name": "2.0.1",
+                "postcss": "6.0.21",
+                "proxy-middleware": "0.15.0",
+                "reflect-metadata": "0.1.12",
+                "rollup": "0.50.0",
+                "rollup-plugin-commonjs": "8.2.6",
+                "rollup-plugin-node-resolve": "3.0.0",
+                "source-map": "0.6.1",
+                "tiny-lr": "1.1.1",
+                "tslint": "5.9.1",
+                "tslint-eslint-rules": "4.1.1",
+                "uglify-es": "3.2.2",
+                "webpack": "3.8.1",
+                "ws": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@ionic/cli-framework": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-0.1.2.tgz",
+            "integrity": "sha512-EEqcpkO7/uo4wt6d2cZHhWjO0yyD6HkEGsrl0ETbfUVJLR0NU3vDi9VvFM8K0NzHOaaHxCKzux+Y3+oJ7utZjA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.3.2",
+                "ncp": "2.0.0",
+                "rimraf": "2.6.2",
+                "strip-ansi": "4.0.0",
+                "superagent": "3.8.2",
+                "tslib": "1.9.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "@ionic/cli-utils": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@ionic/cli-utils/-/cli-utils-1.19.0.tgz",
+            "integrity": "sha512-Wr/QHrZWI2kNDuE1PQUZX5fIoPewPYfa9Ra4LQZ8zrIJzYbmChDOCnyd//zlFvetj3uYuOJRuWUZaiqe5gaziQ==",
+            "dev": true,
+            "requires": {
+                "@ionic/cli-framework": "0.1.2",
+                "@ionic/discover": "0.4.0",
+                "archiver": "2.1.1",
+                "basic-auth": "1.1.0",
+                "body-parser": "1.18.2",
+                "chalk": "2.3.2",
+                "chokidar": "1.7.0",
+                "ci-info": "1.1.3",
+                "cross-spawn": "5.1.0",
+                "dargs": "5.1.0",
+                "diff": "3.5.0",
+                "elementtree": "0.1.7",
+                "express": "4.16.3",
+                "http-proxy-middleware": "0.17.4",
+                "inquirer": "3.3.0",
+                "leek": "0.0.24",
+                "lodash": "4.17.5",
+                "minimist": "1.2.0",
+                "opn": "5.3.0",
+                "os-name": "2.0.1",
+                "semver": "5.5.0",
+                "slice-ansi": "1.0.0",
+                "ssh-config": "1.1.3",
+                "string-width": "2.1.1",
+                "superagent": "3.8.2",
+                "tar": "4.4.1",
+                "tiny-lr": "1.1.1",
+                "tslib": "1.9.0",
+                "uuid": "3.2.1",
+                "wrap-ansi": "3.0.1",
+                "ws": "3.3.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+                    "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+                    "dev": true,
+                    "requires": {
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+                    "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+                    "dev": true
+                }
+            }
+        },
+        "@ionic/discover": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@ionic/discover/-/discover-0.4.0.tgz",
+            "integrity": "sha512-TYls2aGguED/lFLRYP09Q275yQuVJ4PnN1K1lxq3bG3gFP99Txn4UZRaVuYGeezH1A3y2rbdBHjRZBMiUnVvOg==",
+            "dev": true,
+            "requires": {
+                "netmask": "1.0.6"
+            }
+        },
+        "@ionic/storage": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@ionic/storage/-/storage-2.1.3.tgz",
+            "integrity": "sha512-/i3Vn2jNBqteAm5FuGCNei5oJlFQB2JYFkH3nR5f5i7X4kRz17XAsAKXVQjyR9wiye8HmxglIz05JsC92nYUjQ==",
+            "requires": {
+                "@types/localforage": "0.0.30",
+                "localforage": "1.4.3",
+                "localforage-cordovasqlitedriver": "1.5.0"
+            }
+        },
+        "@ngx-translate/core": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-8.0.0.tgz",
+            "integrity": "sha1-dR/WtRLYDzp0jS3o38lt/vopr+A="
+        },
+        "@ngx-translate/http-loader": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-2.0.1.tgz",
+            "integrity": "sha1-qmd4jmS/qGUmkad7Ais7QDEgkRM="
+        },
+        "@types/localforage": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/localforage/-/localforage-0.0.30.tgz",
+            "integrity": "sha1-PWCmv23aOOP4pGlhFZg3nx9klQk="
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "dev": true,
+            "requires": {
+                "mime-types": "2.1.18",
+                "negotiator": "0.6.1"
+            }
+        },
+        "acorn": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+            "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+        },
+        "acorn-dynamic-import": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+            "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+            "dev": true,
+            "requires": {
+                "acorn": "4.0.13"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "4.0.13",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+        },
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "1.9.1"
+            }
+        },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+            "requires": {
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
+            }
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "dev": true
+        },
+        "archiver": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+            "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "async": "2.6.0",
+                "buffer-crc32": "0.2.13",
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "readable-stream": "2.3.5",
+                "tar-stream": "1.5.5",
+                "zip-stream": "1.2.0"
+            }
+        },
+        "archiver-utils": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+            "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lazystream": "1.0.0",
+                "lodash": "4.17.5",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "are-we-there-yet": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+            "dev": true,
+            "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+            "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.5"
+            }
+        },
+        "async-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+        },
+        "async-foreach": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+            "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+            "dev": true
+        },
+        "autoprefixer": {
+            "version": "7.2.6",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+            "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+            "dev": true,
+            "requires": {
+                "browserslist": "2.11.3",
+                "caniuse-lite": "1.0.30000821",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "6.0.21",
+                "postcss-value-parser": "3.3.0"
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "base62": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+            "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
+        },
+        "base64-js": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+            "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+            "dev": true
+        },
+        "basic-auth": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+            "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "big.js": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+        },
+        "bl": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.5",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "body": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+            "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+            "dev": true,
+            "requires": {
+                "continuable-cache": "0.3.1",
+                "error": "7.0.2",
+                "raw-body": "1.1.7",
+                "safe-json-parse": "1.0.1"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+                    "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+                    "dev": true
+                },
+                "raw-body": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+                    "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "1.0.0",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "body-parser": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.16"
+            }
+        },
+        "boom": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-aes": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.6"
+            }
+        },
+        "browserslist": {
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "1.0.30000821",
+                "electron-to-chromium": "1.3.41"
+            }
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "dev": true,
+            "requires": {
+                "base64-js": "1.2.3",
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
+            }
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "dev": true
+        },
+        "camelcase-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
+            }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000821",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz",
+            "integrity": "sha512-qyYay02wr/5k7PO86W+LKFaEUZfWIvT65PaXuPP16jkSpgZGIsSstHKiYAPVLjTj98j2WnWwZg8CjXPx7UIPYg==",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "chalk": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.3.0"
+            }
+        },
+        "chardet": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "dev": true
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "requires": {
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+            }
+        },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+            "dev": true
+        },
+        "ci-info": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+            "dev": true
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "clean-css": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+            "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7"
+            }
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
+        },
+        "compress-commons": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+            "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "crc32-stream": "2.0.0",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+            "dev": true
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
+        "continuable-cache": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+            "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+            "dev": true
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "dev": true
+        },
+        "cookiejar": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+            "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "cordova-android": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-6.4.0.tgz",
+            "integrity": "sha1-VK6NpXKKjX5e/MYXLT3MoXvH/n0=",
+            "requires": {
+                "android-versions": "1.2.1",
+                "cordova-common": "2.1.0",
+                "elementtree": "0.1.6",
+                "nopt": "3.0.6",
+                "properties-parser": "0.2.3",
+                "q": "1.5.0",
+                "shelljs": "0.5.3"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                    "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+                },
+                "android-versions": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.2.1.tgz",
+                    "integrity": "sha1-P1C69pPnOlEsPFQDVCKRzq2QAGM="
+                },
+                "ansi": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                },
+                "base64-js": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                    "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+                },
+                "big-integer": {
+                    "version": "1.6.25",
+                    "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
+                    "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM="
+                },
+                "bplist-parser": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+                    "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+                    "requires": {
+                        "big-integer": "1.6.25"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "cordova-common": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-2.1.0.tgz",
+                    "integrity": "sha1-uzV+4bmCUDHtnbPFa1ku/pc9FkA=",
+                    "requires": {
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
+                        "elementtree": "0.1.6",
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "osenv": "0.1.4",
+                        "plist": "1.2.0",
+                        "q": "1.5.0",
+                        "semver": "5.4.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.8.3",
+                        "unorm": "1.4.1"
+                    }
+                },
+                "cordova-registry-mapper": {
+                    "version": "1.1.15",
+                    "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                    "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
+                },
+                "elementtree": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz",
+                    "integrity": "sha1-KsTEbqMFFsjEy9teOsdBjlkt4gw=",
+                    "requires": {
+                        "sax": "0.3.5"
+                    }
+                },
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "nopt": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                    "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+                    "requires": {
+                        "abbrev": "1.1.0"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "plist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+                    "integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
+                    "requires": {
+                        "base64-js": "0.0.8",
+                        "util-deprecate": "1.0.2",
+                        "xmlbuilder": "4.0.0",
+                        "xmldom": "0.1.27"
+                    }
+                },
+                "properties-parser": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.2.3.tgz",
+                    "integrity": "sha1-91kSVfcHq7/yJ8e1a2N9uwNzoQ8="
+                },
+                "q": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+                    "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+                },
+                "sax": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz",
+                    "integrity": "sha1-iPz8H3PAyLvVt8d2ttPzUB7tBz0="
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+                },
+                "shelljs": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+                    "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                },
+                "unorm": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+                    "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
+                "xmlbuilder": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+                    "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
+                    "requires": {
+                        "lodash": "3.10.1"
+                    }
+                },
+                "xmldom": {
+                    "version": "0.1.27",
+                    "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+                    "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+                }
+            }
+        },
+        "cordova-ios": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-4.5.4.tgz",
+            "integrity": "sha1-yAZIBYlyloVw3BXalzFP+S0H3+c=",
+            "requires": {
+                "cordova-common": "2.1.0",
+                "ios-sim": "6.1.2",
+                "nopt": "3.0.6",
+                "plist": "1.2.0",
+                "q": "1.5.1",
+                "shelljs": "0.5.3",
+                "xcode": "0.9.3",
+                "xml-escape": "1.1.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+                },
+                "ansi": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                },
+                "base64-js": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                    "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+                },
+                "big-integer": {
+                    "version": "1.6.25",
+                    "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
+                    "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM="
+                },
+                "bplist-creator": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+                    "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+                    "requires": {
+                        "stream-buffers": "2.2.0"
+                    }
+                },
+                "bplist-parser": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+                    "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+                    "requires": {
+                        "big-integer": "1.6.25"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "cordova-common": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-2.1.0.tgz",
+                    "integrity": "sha1-uzV+4bmCUDHtnbPFa1ku/pc9FkA=",
+                    "requires": {
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
+                        "elementtree": "0.1.6",
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "osenv": "0.1.4",
+                        "plist": "1.2.0",
+                        "q": "1.5.1",
+                        "semver": "5.4.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.8.3",
+                        "unorm": "1.4.1"
+                    }
+                },
+                "cordova-registry-mapper": {
+                    "version": "1.1.15",
+                    "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                    "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
+                },
+                "elementtree": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz",
+                    "integrity": "sha1-KsTEbqMFFsjEy9teOsdBjlkt4gw=",
+                    "requires": {
+                        "sax": "0.3.5"
+                    }
+                },
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "ios-sim": {
+                    "version": "6.1.2",
+                    "resolved": "https://registry.npmjs.org/ios-sim/-/ios-sim-6.1.2.tgz",
+                    "integrity": "sha512-kWSc7XJfYAGaQSh51UM4pDgXc77vqBS62oBA2tnXsHajk2+xl7Oyt613GYq64eMry2BM1F3tJLGFCJfpp1Ge+A==",
+                    "requires": {
+                        "bplist-parser": "0.0.6",
+                        "nopt": "1.0.9",
+                        "plist": "1.2.0",
+                        "simctl": "1.1.1"
+                    },
+                    "dependencies": {
+                        "bplist-parser": {
+                            "version": "0.0.6",
+                            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
+                            "integrity": "sha1-ONo0cYF9+dRKs4kuJ3B7u9daEbk="
+                        },
+                        "nopt": {
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.9.tgz",
+                            "integrity": "sha1-O8DXy6e/sNWmdtvtfA6+SKT9RU4=",
+                            "requires": {
+                                "abbrev": "1.1.1"
+                            }
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "nopt": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                    "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+                    "requires": {
+                        "abbrev": "1.1.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "pegjs": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+                    "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+                },
+                "plist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+                    "integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
+                    "requires": {
+                        "base64-js": "0.0.8",
+                        "util-deprecate": "1.0.2",
+                        "xmlbuilder": "4.0.0",
+                        "xmldom": "0.1.27"
+                    }
+                },
+                "q": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+                    "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+                },
+                "sax": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz",
+                    "integrity": "sha1-iPz8H3PAyLvVt8d2ttPzUB7tBz0="
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+                },
+                "shelljs": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+                    "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+                },
+                "simctl": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/simctl/-/simctl-1.1.1.tgz",
+                    "integrity": "sha512-yY1WQMq/pneY5jQb2+lFp45qEtcz4yKBu1NOPo2OFDVCkwSkQhpkoaAaO1fWhq4IU0+8TQ2r1PMGSTedP0A/Og==",
+                    "requires": {
+                        "shelljs": "0.2.6",
+                        "tail": "0.4.0"
+                    },
+                    "dependencies": {
+                        "shelljs": {
+                            "version": "0.2.6",
+                            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
+                            "integrity": "sha1-kEktcv/MgVmXa6umL7D2iE8MM3g="
+                        }
+                    }
+                },
+                "simple-plist": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+                    "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+                    "requires": {
+                        "bplist-creator": "0.0.7",
+                        "bplist-parser": "0.1.1",
+                        "plist": "2.0.1"
+                    },
+                    "dependencies": {
+                        "base64-js": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+                            "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+                        },
+                        "plist": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+                            "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+                            "requires": {
+                                "base64-js": "1.1.2",
+                                "xmlbuilder": "8.2.2",
+                                "xmldom": "0.1.27"
+                            }
+                        },
+                        "xmlbuilder": {
+                            "version": "8.2.2",
+                            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+                            "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+                        }
+                    }
+                },
+                "stream-buffers": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+                    "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+                },
+                "tail": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/tail/-/tail-0.4.0.tgz",
+                    "integrity": "sha1-0p3nJ1DMmdseBTr/E8NZ7PtxMAI="
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                },
+                "unorm": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+                    "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
+                "xcode": {
+                    "version": "0.9.3",
+                    "resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
+                    "integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
+                    "requires": {
+                        "pegjs": "0.10.0",
+                        "simple-plist": "0.2.1",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "xml-escape": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+                    "integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ="
+                },
+                "xmlbuilder": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+                    "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
+                    "requires": {
+                        "lodash": "3.10.1"
+                    }
+                },
+                "xmldom": {
+                    "version": "0.1.27",
+                    "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+                    "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+                }
+            }
+        },
+        "cordova-plugin-compat": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-compat/-/cordova-plugin-compat-1.2.0.tgz",
+            "integrity": "sha1-C8ZXVyduvZIMASzpIOJ0F3V2Nz4="
+        },
+        "cordova-plugin-console": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-console/-/cordova-plugin-console-1.1.0.tgz",
+            "integrity": "sha1-4vusECkBeeRMtyxf28QQpTHBzW0="
+        },
+        "cordova-plugin-device": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-1.1.7.tgz",
+            "integrity": "sha1-/JQRG+aTJijGaGiTjd89yCyfv+Y="
+        },
+        "cordova-plugin-inappbrowser": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-inappbrowser/-/cordova-plugin-inappbrowser-1.7.2.tgz",
+            "integrity": "sha1-ZHY0lb6H6y562xoI8CCblupc7uA="
+        },
+        "cordova-plugin-ionic-webview": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-1.1.16.tgz",
+            "integrity": "sha512-57EW4qNkKyCfcVt0pH11s88Dvwdtgf2UkbAyPNk2+T1cmLVQ503S/+3Wa3l173J0NGt/QGGyUM8Z66LkqTnoWg=="
+        },
+        "cordova-plugin-screen-orientation": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-screen-orientation/-/cordova-plugin-screen-orientation-1.4.3.tgz",
+            "integrity": "sha1-pZnocxfKpoQnrJor+bKY+SowQCI="
+        },
+        "cordova-plugin-splashscreen": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-splashscreen/-/cordova-plugin-splashscreen-4.1.0.tgz",
+            "integrity": "sha1-gQKKt2Q+YVWT0n8q0CRFYR8ZRrY="
+        },
+        "cordova-plugin-statusbar": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-2.4.1.tgz",
+            "integrity": "sha1-IiYop4qlTTTUySeZACDQo7rOVUU="
+        },
+        "cordova-plugin-whitelist": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.3.tgz",
+            "integrity": "sha1-tehezbv+Wu3tQKG/TuI3LmfZb7Q="
+        },
+        "cordova-sqlite-storage": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.3.0.tgz",
+            "integrity": "sha512-E6IYvZHUALVGJ3cSsThCpW0sI7JLdv9d2bG/UNZr5+DP5cSlxSTURao0jP6aQmIGAPPLh4xy/j4ImPuEoWtj0A==",
+            "requires": {
+                "cordova-sqlite-storage-dependencies": "1.2.0"
+            }
+        },
+        "cordova-sqlite-storage-dependencies": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-1.2.0.tgz",
+            "integrity": "sha512-lJl5uJFrCWrCYYGhpSEXe6sepjgOOzbeh8fFur3LqaSRvx+xFNYtfMYumE0+xqZwSmPODzex+y6I7ixwcBn73Q=="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "crc": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+            "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+            "dev": true
+        },
+        "crc32-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+            "dev": true,
+            "requires": {
+                "crc": "3.5.0",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "create-ecdh": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.11"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.11"
+            }
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.2",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "dev": true,
+            "requires": {
+                "boom": "5.2.0"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                }
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
+            }
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "1.0.2"
+            }
+        },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "0.10.42"
+            }
+        },
+        "dargs": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+            "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
+        },
+        "doctrine": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+            "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+            "dev": true,
+            "requires": {
+                "esutils": "1.1.6",
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "esutils": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                    "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.3.41",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz",
+            "integrity": "sha1-fjNkPgDNhe39F+BBlPbQDnNzcjU=",
+            "dev": true
+        },
+        "elementtree": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+            "integrity": "sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=",
+            "dev": true,
+            "requires": {
+                "sax": "1.1.4"
+            },
+            "dependencies": {
+                "sax": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                    "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk=",
+                    "dev": true
+                }
+            }
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "enhanced-resolve": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+            "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "object-assign": "4.1.1",
+                "tapable": "0.2.8"
+            }
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "dev": true,
+            "requires": {
+                "prr": "1.0.1"
+            }
+        },
+        "error": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+            "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+            "dev": true,
+            "requires": {
+                "string-template": "0.2.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "es3ify": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
+            "integrity": "sha1-rZ+l3xrjTz8x4SEbWBiy1RB439E=",
+            "requires": {
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "jstransform": "3.0.0",
+                "through": "2.3.8"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.42",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+            "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true,
+            "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
+            }
+        },
+        "esmangle-evaluator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
+            "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
+        },
+        "esprima-fb": {
+            "version": "3001.1.0-dev-harmony-fb",
+            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+            "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "estree-walker": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
+            "integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42"
+            }
+        },
+        "eventemitter3": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+            "dev": true
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "express": {
+            "version": "4.16.3",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.5",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.2",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "finalhandler": "1.1.1",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "2.0.3",
+                "qs": "6.5.1",
+                "range-parser": "1.2.0",
+                "safe-buffer": "5.1.1",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2"
+            },
+            "dependencies": {
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+                    "dev": true
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "external-editor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+            "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+            "dev": true,
+            "requires": {
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.19",
+                "tmp": "0.0.33"
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "falafel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+            "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
+            "requires": {
+                "acorn": "1.2.2",
+                "foreach": "2.0.5",
+                "isarray": "0.0.1",
+                "object-keys": "1.0.11"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                }
+            }
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "dev": true,
+            "requires": {
+                "websocket-driver": "0.7.0"
+            }
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.4.0",
+                "unpipe": "1.0.0"
+            }
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+            }
+        },
+        "formidable": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+            "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+            "dev": true
+        },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+            "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
+            }
+        },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "dev": true,
+            "requires": {
+                "minipass": "2.2.4"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "optional": true,
+            "requires": {
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                }
+            }
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+            }
+        },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+            }
+        },
+        "gaze": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+            "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+            "dev": true,
+            "requires": {
+                "globule": "1.2.0"
+            }
+        },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "requires": {
+                "is-glob": "2.0.1"
+            }
+        },
+        "globule": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+            "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "minimatch": "3.0.4"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "hawk": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+            "dev": true,
+            "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "hoek": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+            "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+            "dev": true,
+            "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+            },
+            "dependencies": {
+                "depd": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+                    "dev": true
+                }
+            }
+        },
+        "http-parser-js": {
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+            "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+            "dev": true
+        },
+        "http-proxy": {
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+            "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "1.2.0",
+                "requires-port": "1.0.0"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+            "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+            "dev": true,
+            "requires": {
+                "http-proxy": "1.16.2",
+                "is-glob": "3.1.0",
+                "lodash": "4.17.5",
+                "micromatch": "2.3.11"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "2.1.1"
+                    }
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+            }
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "in-publish": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "2.0.1"
+            }
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "inline-process-browser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
+            "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
+            "requires": {
+                "falafel": "1.2.0",
+                "through2": "0.6.5"
+            }
+        },
+        "inquirer": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.3.2",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.5",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "dev": true
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "ionic": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/ionic/-/ionic-3.19.0.tgz",
+            "integrity": "sha512-ehkZFkKeq5n2L3Mx087gN9pODHtn8js4QnSklp/rwBa4louBMcUGIfDJ3KiFwJZ95BX2kCwmwCYj7Oa/TKR9yQ==",
+            "dev": true,
+            "requires": {
+                "@ionic/cli-framework": "0.1.2",
+                "@ionic/cli-utils": "1.19.0",
+                "chalk": "2.3.2",
+                "opn": "5.3.0",
+                "semver": "5.5.0",
+                "tslib": "1.9.0"
+            }
+        },
+        "ionic-angular": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/ionic-angular/-/ionic-angular-3.9.2.tgz",
+            "integrity": "sha512-BEZ6magY1i5GwM9ki/MOpszUz62+g518HsGICtw9TE1D4v9Eb6n/o7e+X0vtvpK4TdouFjQ8r5XA9VPAKW9/+Q=="
+        },
+        "ionic-img-viewer": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/ionic-img-viewer/-/ionic-img-viewer-2.9.0.tgz",
+            "integrity": "sha1-GEtXgTEQP53igX8QbD7rHdVjeLc="
+        },
+        "ionic-native-http-connection-backend": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/ionic-native-http-connection-backend/-/ionic-native-http-connection-backend-4.0.5.tgz",
+            "integrity": "sha512-4TlKyRNai13uLPDBZaiyuu5+E6/0gDYzThJ9ZS9s+Mxv3cmGvwLxC13Gr9X1a4BXEDP6QEhEAr2evtBzvwpOZw=="
+        },
+        "ionic-plugin-keyboard": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ionic-plugin-keyboard/-/ionic-plugin-keyboard-2.2.1.tgz",
+            "integrity": "sha1-8qnhabvptVIkADR8n9bTRn7j+hI="
+        },
+        "ionicons": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-3.0.0.tgz",
+            "integrity": "sha1-QLja9P16MRUL0AIWD2ZJbiKpjDw="
+        },
+        "ipaddr.js": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+            "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+            "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "requires": {
+                "binary-extensions": "1.11.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+            "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "is-descriptor": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+            "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "is-odd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+            "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "js-base64": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+            "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "dev": true
+                }
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-loader": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jstransform": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
+            "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
+            "requires": {
+                "base62": "0.1.1",
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "source-map": "0.1.31"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.1.31",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                    "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.5"
+            }
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "leek": {
+            "version": "0.0.24",
+            "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.24.tgz",
+            "integrity": "sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "lodash.assign": "3.2.0",
+                "rsvp": "3.6.2"
+            },
+            "dependencies": {
+                "lodash.assign": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                    "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+                    "dev": true,
+                    "requires": {
+                        "lodash._baseassign": "3.2.0",
+                        "lodash._createassigner": "3.1.1",
+                        "lodash.keys": "3.1.2"
+                    }
+                }
+            }
+        },
+        "lie": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.2.tgz",
+            "integrity": "sha1-/9oh17uibzd8rYZdNkmy/Izjn+o=",
+            "requires": {
+                "es3ify": "0.1.4",
+                "immediate": "3.0.6",
+                "inline-process-browser": "1.0.0",
+                "unreachable-branch-transform": "0.3.0"
+            }
+        },
+        "livereload-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+            "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+            }
+        },
+        "loader-runner": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+            "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+            "dev": true
+        },
+        "loader-utils": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+            "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+            "dev": true,
+            "requires": {
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
+            }
+        },
+        "localforage": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz",
+            "integrity": "sha1-ohJUPDnHx2Qk7dEr9HTEiarKSUw=",
+            "requires": {
+                "lie": "3.0.2"
+            }
+        },
+        "localforage-cordovasqlitedriver": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/localforage-cordovasqlitedriver/-/localforage-cordovasqlitedriver-1.5.0.tgz",
+            "integrity": "sha1-+TR4nmrZo5usBf3RFogS9DhTV2I=",
+            "requires": {
+                "@types/localforage": "0.0.30",
+                "localforage": "1.4.3"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.5",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "dev": true
+        },
+        "lodash._baseassign": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._bindcallback": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+            "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+            "dev": true
+        },
+        "lodash._createassigner": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+            "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+            "dev": true,
+            "requires": {
+                "lodash._bindcallback": "3.0.1",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.restparam": "3.6.1"
+            }
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
+        },
+        "lodash.mergewith": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+            "dev": true
+        },
+        "lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "lru-cache": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
+        },
+        "macos-release": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+            "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+            "dev": true
+        },
+        "magic-string": {
+            "version": "0.22.5",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+            "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+            "dev": true,
+            "requires": {
+                "vlq": "0.2.3"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "1.0.1"
+            }
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
+            "requires": {
+                "errno": "0.1.7",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "meow": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
+        },
+        "mime": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.33.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "minimalistic-assert": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+            "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "minipass": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+            "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+                    "dev": true
+                }
+            }
+        },
+        "minizlib": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+            "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+            "dev": true,
+            "requires": {
+                "minipass": "2.2.4"
+            }
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+            "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        },
+        "nanomatch": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+            "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "ncp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+            "dev": true
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
+            "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
+            "dev": true
+        },
+        "netmask": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+            "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
+        },
+        "node-gyp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+            "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+            "dev": true,
+            "requires": {
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.85.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
+        "node-libs-browser": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+            "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+            "dev": true,
+            "requires": {
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
+                "path-browserify": "0.0.0",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.5",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.1",
+                "string_decoder": "1.0.3",
+                "timers-browserify": "2.0.6",
+                "tty-browserify": "0.0.0",
+                "url": "0.11.0",
+                "util": "0.10.3",
+                "vm-browserify": "0.0.4"
+            }
+        },
+        "node-sass": {
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+            "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+            "dev": true,
+            "requires": {
+                "async-foreach": "0.1.3",
+                "chalk": "1.1.3",
+                "cross-spawn": "3.0.1",
+                "gaze": "1.1.2",
+                "get-stdin": "4.0.1",
+                "glob": "7.1.2",
+                "in-publish": "2.0.0",
+                "lodash.assign": "4.2.0",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.mergewith": "4.6.1",
+                "meow": "3.7.0",
+                "mkdirp": "0.5.1",
+                "nan": "2.10.0",
+                "node-gyp": "3.6.2",
+                "npmlog": "4.1.2",
+                "request": "2.85.0",
+                "sass-graph": "2.2.4",
+                "stdout-stream": "1.4.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.2",
+                        "which": "1.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1.1.1"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "2.0.1"
+            }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
+            "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+            }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "opn": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+            "dev": true,
+            "requires": {
+                "is-wsl": "1.1.0"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
+            "requires": {
+                "lcid": "1.0.0"
+            }
+        },
+        "os-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+            "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+            "dev": true,
+            "requires": {
+                "macos-release": "1.1.0",
+                "win-release": "1.1.1"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "dev": true,
+            "requires": {
+                "p-try": "1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "1.2.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "parse-asn1": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "dev": true,
+            "requires": {
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "1.3.1"
+            }
+        },
+        "parseurl": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "requires": {
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+            "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                }
+            }
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "pbkdf2": {
+            "version": "3.0.14",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.11"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "phonegap-plugin-barcodescanner": {
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/phonegap-plugin-barcodescanner/-/phonegap-plugin-barcodescanner-6.0.8.tgz",
+            "integrity": "sha1-2VxyuKrhaD9jD7wMFt1R7efuROs="
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "postcss": {
+            "version": "6.0.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+            "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.3.2",
+                "source-map": "0.6.1",
+                "supports-color": "5.3.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "proxy-addr": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+            "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+            "dev": true,
+            "requires": {
+                "forwarded": "0.1.2",
+                "ipaddr.js": "1.6.0"
+            }
+        },
+        "proxy-middleware": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+            "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+            "dev": true
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.6"
+            }
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "unpipe": "1.0.0"
+            }
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+            "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "readdirp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.5",
+                "set-immediate-shim": "1.0.1"
+            }
+        },
+        "recast": {
+            "version": "0.10.43",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+            "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+            "requires": {
+                "ast-types": "0.8.15",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.8",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "esprima-fb": {
+                    "version": "15001.1001.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+                }
+            }
+        },
+        "redent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
+            "requires": {
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
+            }
+        },
+        "reflect-metadata": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+            "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "1.0.2"
+            }
+        },
+        "request": {
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+            "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "dev": true,
+            "requires": {
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
+            }
+        },
+        "rollup": {
+            "version": "0.50.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
+            "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ==",
+            "dev": true
+        },
+        "rollup-plugin-commonjs": {
+            "version": "8.2.6",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.6.tgz",
+            "integrity": "sha512-qK0+uhktmnAgZkHkqFuajNmPw93fjrO7+CysDaxWE5jrUR9XSlSvuao5ZJP+XizxA8weakhgYYBtbVz9SGBpjA==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "estree-walker": "0.5.1",
+                "magic-string": "0.22.5",
+                "resolve": "1.6.0",
+                "rollup-pluginutils": "2.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                }
+            }
+        },
+        "rollup-plugin-node-resolve": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
+            "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "1.11.2",
+                "builtin-modules": "1.1.1",
+                "is-module": "1.0.0",
+                "resolve": "1.6.0"
+            }
+        },
+        "rollup-pluginutils": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+            "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+            "dev": true,
+            "requires": {
+                "estree-walker": "0.3.1",
+                "micromatch": "2.3.11"
+            },
+            "dependencies": {
+                "estree-walker": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+                    "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+                    "dev": true
+                }
+            }
+        },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "4.0.8"
+            }
+        },
+        "rxjs": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+            "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
+            "requires": {
+                "symbol-observable": "1.2.0"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "safe-json-parse": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+            "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
+        "sass-graph": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "scss-tokenizer": "0.2.3",
+                "yargs": "7.1.0"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "scss-tokenizer": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+            "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "dev": true,
+            "requires": {
+                "js-base64": "2.4.3",
+                "source-map": "0.4.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "send": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
+            }
+        },
+        "serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
+                "send": "0.16.2"
+            }
+        },
+        "serviceworker-cache-polyfill": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+            "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "sntp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "source-list-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+            "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "dev": true,
+            "requires": {
+                "atob": "2.1.0",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "requires": {
+                "source-map": "0.5.7"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+            "dev": true
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "ssh-config": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ssh-config/-/ssh-config-1.1.3.tgz",
+            "integrity": "sha1-KxljCvhbFmZoi51o9uQhiQD4H4w=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+            "dev": true
+        },
+        "stdout-stream": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+            "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.5"
+            }
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+            "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "string-template": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+            "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
+            "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "4.0.1"
+            }
+        },
+        "superagent": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+            "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "1.2.1",
+                "cookiejar": "2.1.1",
+                "debug": "3.1.0",
+                "extend": "3.0.1",
+                "form-data": "2.3.2",
+                "formidable": "1.2.1",
+                "methods": "1.1.2",
+                "mime": "1.4.1",
+                "qs": "6.5.1",
+                "readable-stream": "2.3.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "supports-color": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "dev": true,
+            "requires": {
+                "has-flag": "3.0.0"
+            }
+        },
+        "sw-toolbox": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+            "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+            "requires": {
+                "path-to-regexp": "1.7.0",
+                "serviceworker-cache-polyfill": "4.0.0"
+            }
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        },
+        "tapable": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+            "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+            "dev": true
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
+        },
+        "tar-stream": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "dev": true,
+            "requires": {
+                "bl": "1.2.2",
+                "end-of-stream": "1.4.1",
+                "readable-stream": "2.3.5",
+                "xtend": "4.0.1"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+            "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
+        "timers-browserify": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+            "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+            "dev": true,
+            "requires": {
+                "setimmediate": "1.0.5"
+            }
+        },
+        "tiny-lr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+            "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
+            "dev": true,
+            "requires": {
+                "body": "5.1.0",
+                "debug": "3.1.0",
+                "faye-websocket": "0.10.0",
+                "livereload-js": "2.3.0",
+                "object-assign": "4.1.1",
+                "qs": "6.5.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "trim-newlines": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "tsickle": {
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.24.1.tgz",
+            "integrity": "sha512-XloFQZhVhgjpQsi3u2ORNRJvuID5sflOg6HfP093IqAbhE1+fIUXznULpdDwHgG4p+v8w78KdHruQtkWUKx5AQ==",
+            "requires": {
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.5.7",
+                "source-map-support": "0.4.18"
+            }
+        },
+        "tslib": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+        },
+        "tslint": {
+            "version": "5.9.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+            "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.3.2",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.11.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.6.0",
+                "semver": "5.5.0",
+                "tslib": "1.9.0",
+                "tsutils": "2.24.0"
+            }
+        },
+        "tslint-eslint-rules": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz",
+            "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
+            "dev": true,
+            "requires": {
+                "doctrine": "0.7.2",
+                "tslib": "1.9.0",
+                "tsutils": "1.9.1"
+            },
+            "dependencies": {
+                "tsutils": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
+                    "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+                    "dev": true
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.24.0.tgz",
+            "integrity": "sha512-rOIkvoe17acR3r96IPnqwa1+Z7zx9AroEtEKl20IeExXtoWptqG/zb806cYOvdbQGcxh1eOaZQNruOQ716Edig==",
+            "dev": true,
+            "requires": {
+                "tslib": "1.9.0"
+            }
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-is": {
+            "version": "1.6.16",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.18"
+            }
+        },
+        "typescript": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+            "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+            "dev": true
+        },
+        "uglify-es": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+            "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+            "dev": true,
+            "requires": {
+                "commander": "2.12.2",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "uglifyjs-webpack-plugin": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+            "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-js": "2.8.29",
+                "webpack-sources": "1.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                    "dev": true,
+                    "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
+                    }
+                },
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                    }
+                }
+            }
+        },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
+        "universalify": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+            "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+            "dev": true
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unreachable-branch-transform": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
+            "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
+            "requires": {
+                "esmangle-evaluator": "1.0.1",
+                "recast": "0.10.43",
+                "through2": "0.6.5"
+            }
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "upath": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+            "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+            "dev": true
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "use": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+            "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
+            }
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            }
+        },
+        "vlq": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+            "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+            "dev": true
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
+        "watchpack": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+            "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+            "dev": true,
+            "requires": {
+                "chokidar": "2.0.3",
+                "graceful-fs": "4.1.11",
+                "neo-async": "2.5.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "3.1.10",
+                        "normalize-path": "2.1.1"
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+                    "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "kind-of": "6.0.2",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "chokidar": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+                    "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.1",
+                        "fsevents": "1.1.3",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.0.4"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "0.1.6"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "3.1.0",
+                        "path-dirname": "1.0.2"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                    "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                    "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+                    "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.1",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    }
+                }
+            }
+        },
+        "webpack": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+            "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "acorn-dynamic-import": "2.0.2",
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "async": "2.6.0",
+                "enhanced-resolve": "3.4.1",
+                "escope": "3.6.0",
+                "interpret": "1.1.0",
+                "json-loader": "0.5.7",
+                "json5": "0.5.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "mkdirp": "0.5.1",
+                "node-libs-browser": "2.1.0",
+                "source-map": "0.5.7",
+                "supports-color": "4.5.0",
+                "tapable": "0.2.8",
+                "uglifyjs-webpack-plugin": "0.4.6",
+                "watchpack": "1.5.0",
+                "webpack-sources": "1.1.0",
+                "yargs": "8.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
+        },
+        "webpack-sources": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+            "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+            "dev": true,
+            "requires": {
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "websocket-driver": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+            "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+            "dev": true,
+            "requires": {
+                "http-parser-js": "0.4.11",
+                "websocket-extensions": "0.1.3"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+            "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+            "dev": true,
+            "requires": {
+                "string-width": "1.0.2"
+            }
+        },
+        "win-release": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+            "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+            "dev": true,
+            "requires": {
+                "semver": "5.5.0"
+            }
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "ws": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+            "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+            }
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dev": true,
+            "requires": {
+                "sax": "1.2.4",
+                "xmlbuilder": "9.0.7"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+            "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "dev": true,
+            "requires": {
+                "camelcase": "3.0.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "5.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "dev": true,
+            "requires": {
+                "camelcase": "3.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        },
+        "zip-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+            "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "compress-commons": "1.2.2",
+                "lodash": "4.17.5",
+                "readable-stream": "2.3.5"
+            }
+        },
+        "zone.js": {
+            "version": "0.8.18",
+            "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
+            "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q=="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "5.0.0",
         "@ionic-native/barcode-scanner": "^3.12.1",
         "@ionic-native/core": "3.10.2",
-        "@ionic-native/local-notifications": "^3.12.1",
+        "@ionic-native/http": "^4.6.0",
         "@ionic-native/screen-orientation": "^3.12.1",
         "@ionic-native/splash-screen": "3.10.2",
         "@ionic-native/status-bar": "3.10.2",
@@ -28,7 +28,6 @@
         "@ngx-translate/core": "^8.0.0",
         "@ngx-translate/http-loader": "^2.0.0",
         "cordova-android": "^6.2.3",
-        "cordova-browser": "^4.1.0",
         "cordova-ios": "^4.5.4",
         "cordova-plugin-compat": "^1.2.0",
         "cordova-plugin-console": "^1.0.7",
@@ -42,6 +41,7 @@
         "cordova-sqlite-storage": "^2.0.4",
         "ionic-angular": "^3.9.2",
         "ionic-img-viewer": "^2.9.0",
+        "ionic-native-http-connection-backend": "^4.0.5",
         "ionic-plugin-keyboard": "^2.2.1",
         "ionicons": "3.0.0",
         "phonegap-plugin-barcodescanner": "^6.0.8",
@@ -96,7 +96,8 @@
             },
             "cordova-sqlite-storage": {},
             "cordova-plugin-inappbrowser": {},
-            "cordova-plugin-ionic-webview": {}
+            "cordova-plugin-ionic-webview": {},
+            "cordova-plugin-advanced-http": {}
         }
     }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,12 +2,10 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { HttpModule, Http } from '@angular/http';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { IonicApp, IonicModule } from 'ionic-angular';
+import { HttpClient, HttpClientModule, HttpBackend, HttpXhrBackend } from '@angular/common/http';
+import { IonicApp, IonicModule, Platform } from 'ionic-angular';
 import { MyApp } from './app.component';
 import { IonicStorageModule } from '@ionic/storage'
-import { LocalNotifications } from '@ionic-native/local-notifications';
 
 //Providers
 import { LibreNMS } from "../providers/libre-nms";
@@ -20,7 +18,9 @@ import { LogProvider } from "../providers/device/log-provider";
 import { GlobalBillProvider } from "../providers/bill-provider";
 import { GlobalAlertProvider } from "../providers/alert-provider";
 
+
 //Native
+import { NativeHttpModule, NativeHttpBackend, NativeHttpFallback } from 'ionic-native-http-connection-backend';
 import { IonicImageViewerModule } from 'ionic-img-viewer';
 import { BarcodeScanner } from '@ionic-native/barcode-scanner';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
@@ -38,9 +38,9 @@ export function createTranslateLoader(http: HttpClient) {
     ],
     imports: [
         BrowserModule,
-        HttpModule,
         IonicImageViewerModule,
         HttpClientModule,
+        NativeHttpModule,
         IonicStorageModule.forRoot(),
         IonicModule.forRoot(MyApp, {
             platforms: {
@@ -74,9 +74,9 @@ export function createTranslateLoader(http: HttpClient) {
         GlobalAlertProvider,
         BarcodeScanner,
         ScreenOrientation,
-        StatusBar,
-        LocalNotifications,
-        CustomValidation
+        StatusBar,        
+        CustomValidation,
+        {provide: HttpBackend, useClass: NativeHttpFallback, deps: [Platform, NativeHttpBackend, HttpXhrBackend]}
     ]
 })
 

--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -39,7 +39,8 @@ export class Dashboard {
         this.ignore = 0;
         this.api.get_credentials().then((credentials: any) => {
             this.url = credentials.url;
-        })
+        });
+        this.checkVersion();
     }
     refresh() {
         this.bad = [];
@@ -72,6 +73,18 @@ export class Dashboard {
         this.navCtrl.push('host', {
             item: item,
             id: item.device_id
+        });
+    }
+
+    checkVersion() {
+        this.api.getRequest('/system').subscribe((response) => {
+            if (response.status == 'error') {
+                let warning = this.toastCtrl.create({
+                    message: "Your LibreNMS server may be out of date, this could cause the application to crash. Be warned",
+                    duration: 5000
+                });
+                warning.present();
+            }
         });
     }
 }

--- a/src/pages/device/host-home/host-home.html
+++ b/src/pages/device/host-home/host-home.html
@@ -1,5 +1,8 @@
 <ion-content>
   <ion-card *ngIf="device">
+    <ion-item *ngIf="error.message">
+      {{error.message}}
+    </ion-item>
     <ion-item>
       <h2>{{device.sysName}}</h2>
       <p>{{device.hardware}}</p>

--- a/src/pages/device/host-home/host-home.ts
+++ b/src/pages/device/host-home/host-home.ts
@@ -18,6 +18,9 @@ export class HostHome {
     traffic_graph: any;
     loading: boolean = true;
     device: Device = null;
+    error: object = {
+        message: null
+    };
     constructor(public navCtrl: NavController,
         public navParams: NavParams,
         private api: LibreNMS,
@@ -34,6 +37,9 @@ export class HostHome {
         this.graphHlpr.get(`devices/${this.id}/device_bits`, 'end-24h', 'now', this.width, 200).then((data: any) => {
             this.traffic_graph = data;
             this.loading = false;
+        })
+        .catch( (message) => {
+            this.error['message'] = message;
         });
     }
     launch(ip) {

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -59,18 +59,13 @@ export class Login {
     }
 
     login(item) {
-        this.api.authenticate(item.url, item.token).subscribe((data) => {
-            this.menu.enable(true);
-            this.storage.set('_session', { 'url': item.url, 'token': item.token, 'version': '/api/v0' });
-            this.navCtrl.setRoot('Dashboard');
+        this.api.authenticate(item.url, item.token, item.basic).subscribe((data) => {
+                this.menu.enable(true);
+                this.storage.set('_session', { 'url': item.url, 'token': item.token, 'version': '/api/v0', 'basic': item.basic });
+                this.navCtrl.setRoot('Dashboard');
         }, (error) => {
-            console.log(JSON.stringify(error));
-            if (error.status == 0) {
-                this.presentToast('Unable to reach the server.');
-            }
-            else {
-                this.presentToast((error.status ? error.status : '') + ':' + (error.statusText ? error.statusText : '') + "\n" + error.json().message);
-            }
+            error = JSON.parse(error);
+            this.presentToast((error.status ? error.status : '') + ':' + (error.message ? error.message : ''));
         });
     }
 

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, ModalController, MenuController, ToastController, Platform } from 'ionic-angular';
 import { LibreNMS } from '../../providers/libre-nms';
 import { Storage } from '@ionic/storage';
-
 @IonicPage({
     priority: 'high'
 })
@@ -65,7 +64,7 @@ export class Login {
             this.storage.set('_session', { 'url': item.url, 'token': item.token, 'version': '/api/v0' });
             this.navCtrl.setRoot('Dashboard');
         }, (error) => {
-            console.log(error.json());
+            console.log(JSON.stringify(error));
             if (error.status == 0) {
                 this.presentToast('Unable to reach the server.');
             }

--- a/src/providers/libre-nms.ts
+++ b/src/providers/libre-nms.ts
@@ -28,11 +28,18 @@ export class LibreNMS {
      * @param token API Token
      * @return Observable Object
      */
-    authenticate(url: string, token: string): Observable<any> {
+    authenticate(url: string, token: string, basic: any = {enabled: false}): Observable<any> {
         return Observable.create((observer) => {
             this.platform.ready().then(() => {
-                this.http.get(`${url}${this.api_version}`, { headers: this.headers(token) }).subscribe((response) => {
-                    observer.next({ 'success': true });
+                if (basic.enabled) this.nativeHttp.useBasicAuth(basic.username, basic.password);
+
+                this.http.get(`${url}${this.api_version}`, { headers: this.headers(token) }).subscribe((response: any) => {
+                    if (response.status == "error") {
+                        observer.error(JSON.stringify(response));
+                    }
+                    else {
+                        observer.next({ 'success': true });
+                    }
                 }, (error) => {
                     observer.error(JSON.stringify(error));
                 }, () => {
@@ -47,6 +54,7 @@ export class LibreNMS {
      */
     logout(): boolean {
         this.storage.set('_session', { 'url': null, 'token': null });
+        this.nativeHttp.useBasicAuth('','');
         return true;
     }
 


### PR DESCRIPTION
This PR has the potential to "break" people running outdated versions of LibreNMS. 

I have added an API endpoint to check the version of libre before display the graphs, so on older LibreNMS installs the graphs will no longer display as the library seems to have issues displaying blob content/types.

The secondary benefit of this PR is we can switch back to the new webview which supports iPhone X.

